### PR TITLE
Add replace for facebook/graph-sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,8 @@
         "psr-4": {
             "Facebook\\Tests\\": "tests/"
         }
+    },
+    "replace": {
+        "facebook/graph-sdk": ">=5.7.0"
     }
 }


### PR DESCRIPTION
To be able to decide wether you want to install this fork optionally there should be a `replace` directive in the `composer.json`.
Thanks to @fritzmg - see: https://github.com/m-vo/contao-facebook-import/pull/34#issuecomment-917431709!

