### PR TITLE
Fix http_build_query PHP8.1 deprecation

### DIFF
--- a/src/Facebook/Authentication/OAuth2Client.php
+++ b/src/Facebook/Authentication/OAuth2Client.php
@@ -143,7 +143,7 @@ class OAuth2Client
             'scope' => implode(',', $scope)
         ];
 
-        return static::BASE_AUTHORIZATION_URL . '/' . $this->graphVersion . '/dialog/oauth?' . http_build_query($params, null, $separator);
+        return static::BASE_AUTHORIZATION_URL . '/' . $this->graphVersion . '/dialog/oauth?' . http_build_query($params, '', $separator);
     }
 
     /**

--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -168,7 +168,7 @@ class FacebookRedirectLoginHelper
             'access_token' => $accessToken->getValue(),
         ];
 
-        return 'https://www.facebook.com/logout.php?' . http_build_query($params, null, $separator);
+        return 'https://www.facebook.com/logout.php?' . http_build_query($params, '', $separator);
     }
 
     /**

--- a/src/Facebook/Http/RequestBodyMultipart.php
+++ b/src/Facebook/Http/RequestBodyMultipart.php
@@ -144,7 +144,7 @@ class RequestBodyMultipart implements RequestBodyInterface
      */
     private function getNestedParams(array $params)
     {
-        $query = http_build_query($params, null, '&');
+        $query = http_build_query($params);
         $params = explode('&', $query);
         $result = [];
 

--- a/src/Facebook/Http/RequestBodyUrlEncoded.php
+++ b/src/Facebook/Http/RequestBodyUrlEncoded.php
@@ -50,6 +50,6 @@ class RequestBodyUrlEncoded implements RequestBodyInterface
      */
     public function getBody()
     {
-        return http_build_query($this->params, null, '&');
+        return http_build_query($this->params);
     }
 }

--- a/src/Facebook/Url/FacebookUrlManipulator.php
+++ b/src/Facebook/Url/FacebookUrlManipulator.php
@@ -53,7 +53,7 @@ class FacebookUrlManipulator
             }
 
             if (count($params) > 0) {
-                $query = '?' . http_build_query($params, null, '&');
+                $query = '?' . http_build_query($params);
             }
         }
 
@@ -81,7 +81,7 @@ class FacebookUrlManipulator
         }
 
         if (strpos($url, '?') === false) {
-            return $url . '?' . http_build_query($newParams, null, '&');
+            return $url . '?' . http_build_query($newParams);
         }
 
         list($path, $query) = explode('?', $url, 2);
@@ -94,7 +94,7 @@ class FacebookUrlManipulator
         // Sort for a predicable order
         ksort($newParams);
 
-        return $path . '?' . http_build_query($newParams, null, '&');
+        return $path . '?' . http_build_query($newParams);
     }
 
     /**


### PR DESCRIPTION
This PR fixes `Deprecated: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated` message in PHP 8.1.