### PR TITLE
__serialize and __unserialize are based on arrays

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 on:
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master

--- a/src/Facebook/FacebookApp.php
+++ b/src/Facebook/FacebookApp.php
@@ -98,7 +98,7 @@ class FacebookApp implements \Serializable
 
     public function __serialize()
     {
-        return $this->serialize();
+        return ['id' => $this->id, 'secret' => $this->secret];
     }
 
     /**
@@ -115,6 +115,6 @@ class FacebookApp implements \Serializable
 
     public function __unserialize($data)
     {
-        $this->unserialize($data);
+        $this->__construct($data['id'], $data['secret']);
     }
 }


### PR DESCRIPTION
@KacerCZ @vgaldikas

The PR I merged (workflow doesn't react to PRs it seems) doesn't pass testing as __serialize must return an array.

This passes. Can we agree that this should also work fine?